### PR TITLE
fix(VolumeMeter): Only reinit Animator if dependencies change

### DIFF
--- a/src/components/VolumeMeter.tsx
+++ b/src/components/VolumeMeter.tsx
@@ -7,7 +7,7 @@ import React, {
   useEffect,
   useRef,
   useState,
-  useMemo
+  useMemo,
 } from "react";
 import { Animator } from "./Animator";
 import { BlockRenderer } from "./BlockRenderer";
@@ -18,7 +18,7 @@ import { Alert, Clickable, MeterDisplay, StyledVolumeMeter } from "./layout";
 export enum VmShape {
   VM_CIRCLE,
   VM_STEPPED,
-  VM_FLAT
+  VM_FLAT,
 }
 
 type Props = {
@@ -46,9 +46,8 @@ export const VolumeMeter = ({
   blocks = 5,
   audioContext,
   stream,
-  activateButton = defaultActivateButton
+  activateButton = defaultActivateButton,
 }: Props) => {
-  console.log("VolumeMeter rendering...");
   const canvas: RefObject<HTMLCanvasElement> = useRef(null);
   const [contextState, setContextState] = useState(audioContext.state);
   const [trackEnabled, setTrackEnabled] = useState(true);
@@ -108,7 +107,7 @@ export const VolumeMeter = ({
           onEnabledChanged: setTrackEnabled,
           onStopCalled: () => {
             setHasEnded(true);
-          }
+          },
         });
 
         setUnableToProvideData(tr.muted);
@@ -152,8 +151,6 @@ export const VolumeMeter = ({
     return new Animator(audioContext, renderer);
   }, [audioContext, canvas.current]);
 
-  console.log(ani);
-
   if (ani) {
     if (anima.current) {
       anima.current.stop();
@@ -169,8 +166,8 @@ export const VolumeMeter = ({
     anima.current = ani;
   }
 
-  const track = stream.map(s => s.getAudioTracks()).map(t => t[0]);
-  const trackCount = stream.map(s => s.getAudioTracks().length).orElse(0);
+  const track = stream.map((s) => s.getAudioTracks()).map((t) => t[0]);
+  const trackCount = stream.map((s) => s.getAudioTracks().length).orElse(0);
 
   // prettier-ignore
   const error = 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,14 +14,9 @@
     "module": "commonjs",
     "target": "es2015",
     "noImplicitAny": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["react"]
   },
   "include": ["src/**/*"],
-  "exclude": [
-
-    "node_modules",
-    "styleguide",
-    "dist",
-    "coverage"
-  ]
+  "exclude": ["node_modules", "styleguide", "dist", "coverage"]
 }


### PR DESCRIPTION
I think the issue was caused by the fact that the Animator was reinitializing whenever VolumeMeter rerendered, since we would run

```
const ani = new Animator(audioContext, renderer);
```

unconditionally.

This PR memoizes the Animator instance so it's only reinitialized if `audioContext` changes.

This is unrelated, but I noticed that Animator might not need to be an event emitter :)